### PR TITLE
[Maint] Fix disk usage in email report

### DIFF
--- a/find_stale_prearchive.sh
+++ b/find_stale_prearchive.sh
@@ -2,6 +2,6 @@
 FOLDER="$PARENT_PATH/prearchive"
 
 # files older than 1 day
-mapfile -t files < <(find "$FOLDER" -type f -mtime +0 -exec dirname {} \; | sort -u | xargs -d '\n' du -sh 2>/dev/null)
+mapfile -t files < <(find "$FOLDER" -type f -mtime +0 -exec dirname {} \; | sort -u | grep -v '^$' | xargs -r  -d '\n' du -sh 2>/dev/null)
 
 python3 send_notification.py "${files[@]}"


### PR DESCRIPTION
Adding arguments to the `xargs ` to avoid calling the `du `command with empty results, which will make it default to the parent folder and report incorrect disk usage